### PR TITLE
Intersection texture fix

### DIFF
--- a/unity-project/Assets/Scripts/GameManager.cs
+++ b/unity-project/Assets/Scripts/GameManager.cs
@@ -16,6 +16,7 @@ public class GameManager : MonoBehaviour
     private RoadNodeCollection roadNodeCollection;
     private List<List<RoadNode>> roadNodesList;
     private Dictionary<RoadNode, RoadMesh> roadMeshes = new Dictionary<RoadNode, RoadMesh>();
+    private RoadMesh roadMesh;
 
     void Start()
     {
@@ -39,7 +40,7 @@ public class GameManager : MonoBehaviour
 
         // Generate mesh
         GameObject roadMeshObj = new GameObject();
-        RoadMesh roadMesh = roadMeshObj.AddComponent(typeof(RoadMesh)) as RoadMesh;
+        roadMesh = roadMeshObj.AddComponent(typeof(RoadMesh)) as RoadMesh;
         roadMesh.GenerateMeshFromPaths(roadNodesList);
     }
 
@@ -59,6 +60,8 @@ public class GameManager : MonoBehaviour
             }
         }
         */
+        //Debug.Log(roadMesh.GetMesh().vertices[roadMesh.GetMesh().vertices.Length-1]);
+        Debug.Log(roadMesh.GetMesh().triangles[roadMesh.GetMesh().triangles.Length-1]);
     }
 
 }

--- a/unity-project/Assets/Scripts/GameManager.cs
+++ b/unity-project/Assets/Scripts/GameManager.cs
@@ -44,24 +44,4 @@ public class GameManager : MonoBehaviour
         roadMesh.GenerateMeshFromPaths(roadNodesList);
     }
 
-    void Update()
-    {
-        // Debug lines
-        /*
-        foreach(List<RoadNode> path in roadNodesList)
-        {
-            for(int i=0; i<path.Count-1; i++)
-            {
-                RoadNode a = path[i];
-                RoadNode b = path[i+1];
-                Vector3 start = new Vector3((a.GetY()-18.05f)*0.5f, 0f, a.GetX()-59.34f)*50f;
-                Vector3 stop = new Vector3((b.GetY()-18.05f)*0.5f, 0f, b.GetX()-59.34f)*50f;
-                Debug.DrawLine(start, stop);
-            }
-        }
-        */
-        //Debug.Log(roadMesh.GetMesh().vertices[roadMesh.GetMesh().vertices.Length-1]);
-        Debug.Log(roadMesh.GetMesh().triangles[roadMesh.GetMesh().triangles.Length-1]);
-    }
-
 }

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -280,8 +280,6 @@ public class RoadMesh : MonoBehaviour
                 triangles.Add(storedIntersectionIndices[(i+1)%storedIntersectionIndices.Count]);
                 triangles.Add(lastIndex); //Finally the midpoint, last in the vertex array
                 Debug.Log("just added: " + triangles[triangles.Count-1]);
-
-                break;
             }
             break;
         }
@@ -289,11 +287,21 @@ public class RoadMesh : MonoBehaviour
         mesh.triangles = triangles.ToArray();
         mesh.uv = uvs.ToArray();
         //Debug.Log("pre triangles ToArray: " + mesh.triangles.ToArray()[mesh.triangles.ToArray().Length-1]);
+        //
+        Debug.Log("tri 1: " + triangles[triangles.Count-1]);
+        Debug.Log("tri 2: " + triangles[triangles.Count-4]);
+        Debug.Log("tri 3: " + triangles[triangles.Count-7]);
+        Debug.Log("tri 4: " + triangles[triangles.Count-10]);
+        //
         Debug.Log("Last triangle in list: " + triangles[triangles.Count-1]);
         Debug.Log("just triangles ToArray: " + triangles.ToArray()[triangles.ToArray().Length-1]);
         Debug.Log("just build triangles: " + mesh.triangles[mesh.triangles.Count()-1]); // Always points to 1244 for some reason
         mesh.triangles[mesh.triangles.Count()-1] = 66780;
         Debug.Log("just altered triangles: " + mesh.triangles[mesh.triangles.Count()-1]);
+        Debug.Log("tri 1: " + mesh.triangles[mesh.triangles.Count()-1]);
+        Debug.Log("tri 2: " + mesh.triangles[mesh.triangles.Count()-4]);
+        Debug.Log("tri 3: " + mesh.triangles[mesh.triangles.Count()-7]);
+        Debug.Log("tri 4: " + mesh.triangles[mesh.triangles.Count()-10]);
         
 
 

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -249,8 +249,8 @@ public class RoadMesh : MonoBehaviour
                     vertices.Add(storedIntersections[i]);
                     vertices.Add(storedIntersections[(i+1)%storedIntersections.Count]);
                     // Set UV x offset depending on which highway type this path is
-                    uvs.Add(new Vector2(uvXOffset*0.25f, 0f)); // Every other corner get uv.x = 1 or 0
-                    uvs.Add(new Vector2(uvXOffset*0.25f+0.25f, 0f)); // Every other corner get uv.x = 1 or 0
+                    uvs.Add(new Vector2(uvXOffset, 0f)); // Every other corner get uv.x = 1 or 0
+                    uvs.Add(new Vector2(uvXOffset+0.25f, 0f)); // Every other corner get uv.x = 1 or 0
 
                     // Create new triangles, stitch all the vertices together
                     triangles.Add(0); // Mid point, was added first

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -252,12 +252,14 @@ public class RoadMesh : MonoBehaviour
             //midPoint = Vector3.zero;
 
             // Add the midpoint of the intersection as the next vertex
-            vertices.Add(midPoint);
             uvs.Add(new Vector2(0.5f, 0.5f));
-            //GameObject tempMarker = new GameObject();
-            //tempMarker.name = "Intersection marker " + c;
-            //c++;
-            //tempMarker.transform.position = midPoint;
+            GameObject tempMarker = new GameObject();
+            tempMarker.name = "Midpoint marker " + c;
+            c++;
+            tempMarker.transform.position = midPoint;
+
+            vertices.Add(midPoint);
+            countedVertices++;
 
             for(int i=0; i< storedIntersectionIndices.Count; i++)
             {
@@ -274,35 +276,56 @@ public class RoadMesh : MonoBehaviour
                 tempMarkerT3.transform.position = vertices[vertices.Count-1];
 
                 // Create new triangles, stitch all the vertices together
-                int lastIndex = vertices.Count-1;
-                Debug.Log("last index: " + lastIndex);
+                //Debug.Log("countedVertices: " + countedVertices);
                 triangles.Add(storedIntersectionIndices[i]);
                 triangles.Add(storedIntersectionIndices[(i+1)%storedIntersectionIndices.Count]);
-                triangles.Add(lastIndex); //Finally the midpoint, last in the vertex array
-                Debug.Log("just added: " + triangles[triangles.Count-1]);
+                //triangles.Add(0); // WORKS FINE!
+                triangles.Add(countedVertices-1); // DOES NOT WORK
+                // the index gets -65536 every time
+                //Debug.Log("0-vertex: " + vertices[0]);
+                //triangles.Add(lastIndex); //Finally the midpoint, last in the vertex array
+                // FIXME: I know what the problem is! Unity has a 65536 vertex limit, thus it loops around. This might also explain why some roads do not appear
+                // TODO: Spawn submeshes instead, for every step of the loop
             }
-            break;
         }
+
+        int[] trisArray = new int[triangles.Count];
+        for(int i=0; i<triangles.Count; i++)
+        {
+            trisArray[i] = triangles[i];
+        }
+
         mesh.vertices = vertices.ToArray();
-        mesh.triangles = triangles.ToArray();
+        mesh.SetIndices(trisArray, MeshTopology.Triangles, 0);
+        //mesh.triangles = trisArray;
         mesh.uv = uvs.ToArray();
         //Debug.Log("pre triangles ToArray: " + mesh.triangles.ToArray()[mesh.triangles.ToArray().Length-1]);
         //
         Debug.Log("tri 1: " + triangles[triangles.Count-1]);
-        Debug.Log("tri 2: " + triangles[triangles.Count-4]);
-        Debug.Log("tri 3: " + triangles[triangles.Count-7]);
-        Debug.Log("tri 4: " + triangles[triangles.Count-10]);
+        Debug.Log("tri 10: " + triangles[triangles.Count-10]);
+        Debug.Log("tri 11: " + triangles[triangles.Count-11]);
+        //Debug.Log("tri 3: " + triangles[triangles.Count-7]);
+        //Debug.Log("tri 4: " + triangles[triangles.Count-10]);
         //
-        Debug.Log("Last triangle in list: " + triangles[triangles.Count-1]);
-        Debug.Log("just triangles ToArray: " + triangles.ToArray()[triangles.ToArray().Length-1]);
-        Debug.Log("just build triangles: " + mesh.triangles[mesh.triangles.Count()-1]); // Always points to 1244 for some reason
-        mesh.triangles[mesh.triangles.Count()-1] = 66780;
-        Debug.Log("just altered triangles: " + mesh.triangles[mesh.triangles.Count()-1]);
+        //Debug.Log("Last triangle in list: " + triangles[triangles.Count-1]);
+        //Debug.Log("just triangles ToArray: " + triangles.ToArray()[triangles.ToArray().Length-1]);
+        //Debug.Log("just build triangles: " + mesh.triangles[mesh.triangles.Count()-1]); // Always points to 1244 for some reason
+        //mesh.triangles[mesh.triangles.Count()-1] = 66780;
+        //Debug.Log("just altered triangles: " + mesh.triangles[mesh.triangles.Count()-1]);
         Debug.Log("tri 1: " + mesh.triangles[mesh.triangles.Count()-1]);
-        Debug.Log("tri 2: " + mesh.triangles[mesh.triangles.Count()-4]);
-        Debug.Log("tri 3: " + mesh.triangles[mesh.triangles.Count()-7]);
-        Debug.Log("tri 4: " + mesh.triangles[mesh.triangles.Count()-10]);
+        Debug.Log("tri 10: " + mesh.triangles[mesh.triangles.Count()-10]);
+        Debug.Log("tri 11: " + mesh.triangles[mesh.triangles.Count()-11]);
+        //Debug.Log("tri 2: " + mesh.triangles[mesh.triangles.Count()-4]);
+        //Debug.Log("tri 3: " + mesh.triangles[mesh.triangles.Count()-7]);
+        //Debug.Log("tri 4: " + mesh.triangles[mesh.triangles.Count()-10]);
         
+        //for(int i=0; i<triangles.Count; i++)
+        //{
+            //if(triangles[i] != mesh.triangles[i])
+            //{
+                //Debug.LogError("Mesh triangle index " + i + " did not match!");
+            //}
+        //}
 
 
         // Build normals


### PR DESCRIPTION
Fixes #2. The issue that the mesh contained too many vertices was solved by splitting every road and intersection into its own mesh. This caused frame rate drops. Opening a new issue about this, see #11.