### PR TITLE
B02.20 intersections fix unity

### DIFF
--- a/unity-project/Assets/Scenes/SampleScene.unity
+++ b/unity-project/Assets/Scenes/SampleScene.unity
@@ -739,7 +739,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: 0.01
   far clip plane: 1000
   field of view: 60
   orthographic: 0

--- a/unity-project/Assets/Scenes/SampleScene.unity
+++ b/unity-project/Assets/Scenes/SampleScene.unity
@@ -120,6 +120,184 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &37315434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 37315435}
+  - component: {fileID: 37315436}
+  m_Layer: 0
+  m_Name: MapDebugHelper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &37315435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 37315434}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &37315436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 37315434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b3e5b9ba5a22eac292714ff0044e2ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _coordXText: {fileID: 1858664124}
+  _coordYText: {fileID: 1505840544}
+--- !u!1 &602289885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 602289886}
+  - component: {fileID: 602289889}
+  - component: {fileID: 602289888}
+  - component: {fileID: 602289887}
+  m_Layer: 5
+  m_Name: FocusButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &602289886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 602289885}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1509485336}
+  m_Father: {fileID: 1526750145}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 100, y: -140}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &602289887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 602289885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 602289888}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 37315436}
+        m_MethodName: FocusOnNodeButtonCallback
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &602289888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 602289885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &602289889
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 602289885}
+  m_CullTransparentMesh: 0
 --- !u!1 &663817407
 GameObject:
   m_ObjectHideFlags: 0
@@ -353,6 +531,164 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &724889253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 724889254}
+  - component: {fileID: 724889256}
+  - component: {fileID: 724889255}
+  m_Layer: 5
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &724889254
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724889253}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1858664123}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &724889255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724889253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enter text...
+--- !u!222 &724889256
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724889253}
+  m_CullTransparentMesh: 0
+--- !u!1 &940348076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 940348077}
+  - component: {fileID: 940348079}
+  - component: {fileID: 940348078}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &940348077
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940348076}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1858664123}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &940348078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940348076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &940348079
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940348076}
+  m_CullTransparentMesh: 0
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -454,6 +790,85 @@ MonoBehaviour:
   _snapSpeed: 6
   _minZoomLevel: 1
   _maxZoomLevel: 10
+--- !u!1 &1300408274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1300408275}
+  - component: {fileID: 1300408277}
+  - component: {fileID: 1300408276}
+  m_Layer: 5
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1300408275
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1300408274}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1505840543}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1300408276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1300408274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enter text...
+--- !u!222 &1300408277
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1300408274}
+  m_CullTransparentMesh: 0
 --- !u!1 &1444848837
 GameObject:
   m_ObjectHideFlags: 0
@@ -491,9 +906,625 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1444848837}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 6.144524, y: 0, z: -7.995605}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1505840542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1505840543}
+  - component: {fileID: 1505840546}
+  - component: {fileID: 1505840545}
+  - component: {fileID: 1505840544}
+  m_Layer: 5
+  m_Name: CoordYInputField
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1505840543
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1505840542}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1300408275}
+  - {fileID: 2140733059}
+  m_Father: {fileID: 1526750145}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 100, y: -90}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1505840544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1505840542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1505840545}
+  m_TextComponent: {fileID: 2140733060}
+  m_Placeholder: {fileID: 1300408276}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+SubmitEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+OnChangeEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+--- !u!114 &1505840545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1505840542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1505840546
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1505840542}
+  m_CullTransparentMesh: 0
+--- !u!1 &1509485335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1509485336}
+  - component: {fileID: 1509485338}
+  - component: {fileID: 1509485337}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1509485336
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509485335}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 602289886}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1509485337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509485335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Button
+--- !u!222 &1509485338
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1509485335}
+  m_CullTransparentMesh: 0
+--- !u!1 &1526750144
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1526750145}
+  - component: {fileID: 1526750148}
+  - component: {fileID: 1526750147}
+  - component: {fileID: 1526750146}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1526750145
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526750144}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1858664123}
+  - {fileID: 1505840543}
+  - {fileID: 602289886}
+  m_Father: {fileID: 1728040034}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1526750146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526750144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1526750147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526750144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1526750148
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526750144}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &1728040031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1728040034}
+  - component: {fileID: 1728040033}
+  - component: {fileID: 1728040032}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1728040032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728040031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1728040033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728040031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1728040034
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728040031}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1526750145}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1858664122
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1858664123}
+  - component: {fileID: 1858664126}
+  - component: {fileID: 1858664125}
+  - component: {fileID: 1858664124}
+  m_Layer: 5
+  m_Name: CoordXInputField
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1858664123
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1858664122}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 724889254}
+  - {fileID: 940348077}
+  m_Father: {fileID: 1526750145}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 100, y: -40}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1858664124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1858664122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1858664125}
+  m_TextComponent: {fileID: 940348078}
+  m_Placeholder: {fileID: 724889255}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+SubmitEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+OnChangeEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+--- !u!114 &1858664125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1858664122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1858664126
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1858664122}
+  m_CullTransparentMesh: 0
+--- !u!1 &2140733058
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2140733059}
+  - component: {fileID: 2140733061}
+  - component: {fileID: 2140733060}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2140733059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2140733058}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1505840543}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2140733060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2140733058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &2140733061
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2140733058}
+  m_CullTransparentMesh: 0

--- a/unity-project/Assets/Scripts/GameManager.cs
+++ b/unity-project/Assets/Scripts/GameManager.cs
@@ -30,7 +30,16 @@ public class GameManager : MonoBehaviour
             foreach(FeatureObject feature in collection.features)
             {
                 List<Vector2> path = new List<Vector2>();
-                List<PositionObject> positions = feature.geometry.AllPositions();
+                GeometryObject geometryObject = feature.geometry;
+
+                // Don't treat polygon objects, just skip them
+                if(geometryObject as PolygonGeometryObject != null
+                        || geometryObject as MultiPolygonGeometryObject != null)
+                {
+                    continue;
+                }
+
+                List<PositionObject> positions = geometryObject.AllPositions();
                 foreach(PositionObject position in positions)
                 {
                     path.Add(new Vector2(position.latitude, position.longitude));

--- a/unity-project/Assets/Scripts/GameManager.cs
+++ b/unity-project/Assets/Scripts/GameManager.cs
@@ -14,7 +14,7 @@ public class GameManager : MonoBehaviour
     };
 
     private RoadNodeCollection roadNodeCollection;
-    private List<List<RoadNode>> roadNodesList;
+    private List<RoadPath> roadNodesList;
     private Dictionary<RoadNode, RoadMesh> roadMeshes = new Dictionary<RoadNode, RoadMesh>();
     private RoadMesh roadMesh;
     private List<List<Vector2>> rawPaths = new List<List<Vector2>>();

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -11,11 +11,14 @@ public class MapDebugHelper : MonoBehaviour
     [SerializeField] private InputField _coordXText;
     [SerializeField] private InputField _coordYText;
 
+    private static GameObject _pointMarker;
+
     private static MapDebugHelper _instance;
 
     private void Awake()
     {
         _instance = this;
+        _pointMarker = Resources.Load("Prefabs/PolygonMarker") as GameObject;
     }
 
     public void FocusOnNodeButtonCallback()
@@ -24,6 +27,9 @@ public class MapDebugHelper : MonoBehaviour
         float y = float.Parse(_coordYText.text);
 
         Camera.main.transform.position = new Vector3(x, 0.05f, y);
+
+        GameObject pointMarker = Instantiate(_pointMarker, new Vector3(x, 0.001f, y), Quaternion.identity);
+        pointMarker.transform.localScale = 0.015f* new Vector3(1f, 1f, 1f);
     }
 
     public static void ConditionalNodeLog(RoadNode node, string msg)

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -29,7 +29,7 @@ public class MapDebugHelper : MonoBehaviour
         Camera.main.transform.position = new Vector3(x, 0.05f, y);
 
         GameObject pointMarker = Instantiate(_pointMarker, new Vector3(x, 0.001f, y), Quaternion.identity);
-        pointMarker.transform.localScale = 0.015f* new Vector3(1f, 1f, 1f);
+        pointMarker.transform.localScale = 0.0015f* new Vector3(1f, 1f, 1f);
     }
 
     public static void ConditionalNodeLog(RoadNode node, string msg)

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -21,6 +21,11 @@ public class MapDebugHelper : MonoBehaviour
         _pointMarker = Resources.Load("Prefabs/PolygonMarker") as GameObject;
     }
 
+    private void Start()
+    {
+        Camera.main.transform.position = new Vector3((float)targetNodeX, 0.05f, (float)targetNodeY);
+    }
+
     public void FocusOnNodeButtonCallback()
     {
         float x = float.Parse(_coordXText.text);

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MapDebugHelper : MonoBehaviour
+{
+    private static float targetNodeX = 6.144524;
+    private static float targetNodeY = -7.995605;
+
+    public static void ConditionalNodeLog(RoadNode node, string msg)
+    {
+        ConditionalNodeLog(new Vector2(node.GetX(), node.GetY()));
+    }
+
+    public static void ConditionalNodeLog(Vector3 point, string msg)
+    {
+        ConditionalNodeLog(new Vector2(point.x, point.z));
+    }
+
+    public static void ConditionalNodeLog(Vector2 point, string msg)
+    {
+        Vector3 p = RoadMesh.TransformPointToMeshSpace(point);
+        if(p.x-0.00005 < targetNodeX && p.x+0.00005 > targetNodeX
+            && p.z-0.00005 < targetNodeY && p.z+0.00005 > targetNodeY)
+        {
+            Debug.Log(msg);
+        }
+    }
+}

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -23,7 +23,7 @@ public class MapDebugHelper : MonoBehaviour
         float x = float.Parse(_coordXText.text);
         float y = float.Parse(_coordYText.text);
 
-        Camera.main.transform.position = new Vector3(x, 2f, y);
+        Camera.main.transform.position = new Vector3(x, 0.05f, y);
     }
 
     public static void ConditionalNodeLog(RoadNode node, string msg)

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -4,17 +4,17 @@ using UnityEngine;
 
 public class MapDebugHelper : MonoBehaviour
 {
-    private static float targetNodeX = 6.144524;
-    private static float targetNodeY = -7.995605;
+    private static double targetNodeX = 6.144524;
+    private static double targetNodeY = -7.995605;
 
     public static void ConditionalNodeLog(RoadNode node, string msg)
     {
-        ConditionalNodeLog(new Vector2(node.GetX(), node.GetY()));
+        ConditionalNodeLog(new Vector2(node.GetX(), node.GetY()), msg);
     }
 
     public static void ConditionalNodeLog(Vector3 point, string msg)
     {
-        ConditionalNodeLog(new Vector2(point.x, point.z));
+        ConditionalNodeLog(new Vector2(point.x, point.z), msg);
     }
 
     public static void ConditionalNodeLog(Vector2 point, string msg)

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs
@@ -1,11 +1,30 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class MapDebugHelper : MonoBehaviour
 {
     private static double targetNodeX = 6.144524;
     private static double targetNodeY = -7.995605;
+
+    [SerializeField] private InputField _coordXText;
+    [SerializeField] private InputField _coordYText;
+
+    private static MapDebugHelper _instance;
+
+    private void Awake()
+    {
+        _instance = this;
+    }
+
+    public void FocusOnNodeButtonCallback()
+    {
+        float x = float.Parse(_coordXText.text);
+        float y = float.Parse(_coordYText.text);
+
+        Camera.main.transform.position = new Vector3(x, 2f, y);
+    }
 
     public static void ConditionalNodeLog(RoadNode node, string msg)
     {

--- a/unity-project/Assets/Scripts/MapDebugHelper.cs.meta
+++ b/unity-project/Assets/Scripts/MapDebugHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b3e5b9ba5a22eac292714ff0044e2ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/Scripts/MathUtils.cs
+++ b/unity-project/Assets/Scripts/MathUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class MathUtils : MonoBehaviour
@@ -73,4 +74,21 @@ public class MathUtils : MonoBehaviour
 			return false;
 		}
 	}
+
+    public static Vector3 FindCentroid(List<Vector3> points) {
+        float x = 0;
+        float y = 0;
+        float z = 0;
+        foreach (Vector3 p in points) {
+            x += p.x;
+            y += p.y;
+            z += p.z;
+        }
+        Vector3 center = new Vector3(0, 0);
+        center.x = x / points.Count;
+        center.y = y / points.Count;
+        center.z = z / points.Count;
+        return center;
+    }
+
 }

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -153,8 +153,6 @@ public class RoadMesh : MonoBehaviour
                     // Have to swap places of the right/left vertices here, at the end of the path, so that the intersection checker
                     // really looks at the left end point of a and right end point of b
                     intersectionNodes[b].Add(new RoadEndPoint(rightEndPoint, leftEndPoint, vertices.Count-1, vertices.Count-2, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
-
-                    MapDebugHelper.ConditionalNodeLog(b, "Tracer node was found when reading paths. Added a b-intersection");
                 }
                 // If this is the beginning or end node of the path, store it as an intersection candidate
                 if(a.IsIntersection())
@@ -165,7 +163,6 @@ public class RoadMesh : MonoBehaviour
                     }
                     // Negative tangent so that the tangent always points inwards to the intersection, both for a- and b-intersections
                     intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, -tangent, hwyType, storedPathMeshes[currentMeshCounter]));
-                    MapDebugHelper.ConditionalNodeLog(a, "Tracer node was found when reading paths. Added a a-intersection");
                 }
             }
             if(vertices.Count > 20000)
@@ -221,7 +218,6 @@ public class RoadMesh : MonoBehaviour
                             + b.rightPoint.x + ", " + b.rightPoint.z + "), (a.tangent = "
                             + a.tangent.x + ", " + a.tangent.z + "), b.tangent = "
                             + b.tangent.x + ", " + b.tangent.z + ")";
-                MapDebugHelper.ConditionalNodeLog(node, msg);
                 
                 // Get the intersection point
                 // Get the right pos from end point 1 and left pos from end point 2
@@ -231,7 +227,6 @@ public class RoadMesh : MonoBehaviour
                     b.rightPoint, b.tangent))
                 {
                     intersectionWasSet = true;
-                    MapDebugHelper.ConditionalNodeLog(node, "Linear intersection found at: " + intersection.x + ", " + intersection.z);
                 }
                 else if((a.tangent + b.tangent).magnitude < 0.01f)
                 {
@@ -290,9 +285,6 @@ public class RoadMesh : MonoBehaviour
                     // Save the vertex to this mesh
                     vertices.Add(endVertex1);
                     vertices.Add(endVertex2);
-
-                    MapDebugHelper.ConditionalNodeLog(node, "End vertex 1: " + endVertex1.x + ", " + endVertex1.z);
-                    MapDebugHelper.ConditionalNodeLog(node, "End vertex 2: " + endVertex2.x + ", " + endVertex2.z);
 
                     // Set UV x offset depending on which highway type this path is
                     uvs.Add(new Vector2(uvXOffset, 0f)); // Every other corner get uv.x = 1 or 0

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -140,17 +140,17 @@ public class RoadMesh : MonoBehaviour
 
                 // Set the last end point for the next path segment
                 previousRoadEndPoint = new RoadEndPoint(leftEndPoint, rightEndPoint, vertices.Count-2, vertices.Count-1, tangent, hwyType, storedPathMeshes[currentMeshCounter]);
-
-                // If this is the beginning or end node of the path, store it as an intersection candidate
-                if(i==0)
+                
+                Vector2 po = new Vector2(b.GetX(), b.GetY());
+                po = RoadMesh.TransformPointToMeshSpace(po);
+                if(po.x-0.00001 < 6.56414 && po.x+0.00001 > 6.56414
+                    && po.y-0.00001 < 3.492355 && po.y+0.00001 > -3.492355)
                 {
-                    if(!intersectionNodes.ContainsKey(a))
-                    {
-                        intersectionNodes[a] = new List<RoadEndPoint>();
-                    }
-                    intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+                    Debug.Log("Tracer node was found when reading paths. Index " + i + " out of " + (path.Count-1));
                 }
-                else if(i==path.Count-2)
+
+
+                if(i==path.Count-2 || (path.Count==2 && i==0))
                 {
                     if(!intersectionNodes.ContainsKey(b))
                     {
@@ -159,6 +159,30 @@ public class RoadMesh : MonoBehaviour
                     // Have to swap places of the right/left vertices here, at the end of the path, so that the intersection checker
                     // really looks at the left end point of a and right end point of b
                     intersectionNodes[b].Add(new RoadEndPoint(rightEndPoint, leftEndPoint, vertices.Count-1, vertices.Count-2, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+
+                    Vector2 p = new Vector2(b.GetX(), b.GetY());
+                    p = RoadMesh.TransformPointToMeshSpace(p);
+                    if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                        && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+                    {
+                        Debug.Log("Tracer node: added an intersection in the end, tangent: " + tangent);
+                    }
+                }
+                // If this is the beginning or end node of the path, store it as an intersection candidate
+                else if(i==0)
+                {
+                    if(!intersectionNodes.ContainsKey(a))
+                    {
+                        intersectionNodes[a] = new List<RoadEndPoint>();
+                    }
+                    intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+                    Vector2 p = new Vector2(a.GetX(), a.GetY());
+                    p = RoadMesh.TransformPointToMeshSpace(p);
+                    if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                        && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+                    {
+                        Debug.Log("Tracer node: added an intersection in the beginning, tangent: " + tangent);
+                    }
                 }
             }
             if(vertices.Count > 20000)

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -216,17 +216,12 @@ public class RoadMesh : MonoBehaviour
 
                 midPoint += (a.rightPoint + a.leftPoint)/2;
 
-                Vector2 p2 = new Vector3(node.GetX(), node.GetY());
-                Vector3 p = RoadMesh.TransformPointToMeshSpace(p2);
-                if(p.x-0.00005 < 6.144524 && p.x+0.00005 > 6.144524
-                    && p.z-0.00005 < -7.995605 && p.z+0.00005 > -7.995605)
-                {
-                    Debug.Log("Endpoint collision check: (a.rightPoint = "
+                string msg = "Endpoint collision check: (a.rightPoint = "
                             + a.rightPoint.x + ", " + a.rightPoint.z + "), (b.leftPoint = "
                             + b.leftPoint.x + ", " + b.leftPoint.z + "), (a.tangent = "
                             + a.tangent.x + ", " + a.tangent.z + "), b.tangent = "
-                            + b.tangent.x + ", " + b.tangent.z + ")");
-                }
+                            + b.tangent.x + ", " + b.tangent.z + ")";
+                MapDebugHelper.ConditionalNodeLog(node, msg);
                 
                 // Get the intersection point
                 // Get the right pos from end point 1 and left pos from end point 2

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -48,7 +48,7 @@ public class RoadMesh : MonoBehaviour
         {RoadNode.HighwayType.PRIMARY, 1f}
     };
 
-    public void GenerateMeshFromPaths(List<List<RoadNode>> paths)
+    public void GenerateMeshFromPaths(List<RoadPath> paths)
     {
         // Start building path mesh
         List<Vector3> vertices = new List<Vector3>();
@@ -59,7 +59,7 @@ public class RoadMesh : MonoBehaviour
         int countedVertices = 0;
 
         Dictionary<RoadNode, List<RoadEndPoint>> intersectionNodes = new Dictionary<RoadNode, List<RoadEndPoint>>();
-        foreach(List<RoadNode> path in paths)
+        foreach(RoadPath path in paths)
         {
             // First create the mesh we'll be working with
             if(storedPathMeshes.Count <= currentMeshCounter) 
@@ -71,10 +71,10 @@ public class RoadMesh : MonoBehaviour
 
             RoadNode.HighwayType hwyType = RoadNode.HighwayType.NONE;
 
-            for(int i=0; i<path.Count-1; i++)
+            for(int i=0; i<path.Count()-1; i++)
             {
-                RoadNode a = path[i];
-                RoadNode b = path[i+1];
+                RoadNode a = path.Get(i);
+                RoadNode b = path.Get(i+1);
 
                 // Get hwy type from the second node in the path, since the intersection may be of another type
                 if(hwyType == RoadNode.HighwayType.NONE) hwyType = b.GetHighwayType();
@@ -280,7 +280,7 @@ public class RoadMesh : MonoBehaviour
                 {
                     // Add the midpoint of the intersection as the next vertex
                     // Set UV x offset depending on which highway type this path is
-                    RoadNode.HighwayType hwyType = endPoints[(i+1)%storedIntersections.Count].hwyType;
+                    RoadNode.HighwayType hwyType = endPoints[i].hwyType;
                     float uvXOffset = _uvXOffsetByHwyType[hwyType];
                     uvs.Add(new Vector2(uvXOffset+0.125f, 0.5f));
                     vertices.Add(midPoint); // Add the midpoint as a new vertex for every triangle, so each triangle gets unique UV coordinates

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -213,7 +213,7 @@ public class RoadMesh : MonoBehaviour
             }
 
             // Order the end points by angle
-            RoadEndPoint[] endPointsSorted = endPoints.OrderBy(v => Vector3.Angle(v.tangent, Vector3.right)).ToArray();
+            RoadEndPoint[] endPointsSorted = endPoints.OrderBy(v => Vector3.SignedAngle(v.tangent, Vector3.right, -Vector3.up)).ToArray();
 
             List<Vector3> storedIntersections = new List<Vector3>();
 

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -150,8 +150,7 @@ public class RoadMesh : MonoBehaviour
                     Debug.Log("Tracer node was found when reading paths. Index " + i + " out of " + (path.Count-1));
                 }
 
-
-                if(i==path.Count-2 || (path.Count==2 && i==0))
+                if(b.IsIntersection())
                 {
                     if(!intersectionNodes.ContainsKey(b))
                     {
@@ -160,30 +159,15 @@ public class RoadMesh : MonoBehaviour
                     // Have to swap places of the right/left vertices here, at the end of the path, so that the intersection checker
                     // really looks at the left end point of a and right end point of b
                     intersectionNodes[b].Add(new RoadEndPoint(rightEndPoint, leftEndPoint, vertices.Count-1, vertices.Count-2, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
-
-                    Vector2 p = new Vector2(b.GetX(), b.GetY());
-                    p = RoadMesh.TransformPointToMeshSpace(p);
-                    if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                        && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-                    {
-                        Debug.Log("Tracer node: added an intersection in the end, tangent: " + tangent);
-                    }
                 }
                 // If this is the beginning or end node of the path, store it as an intersection candidate
-                else if(i==0)
+                if(a.IsIntersection())
                 {
                     if(!intersectionNodes.ContainsKey(a))
                     {
                         intersectionNodes[a] = new List<RoadEndPoint>();
                     }
                     intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
-                    Vector2 p = new Vector2(a.GetX(), a.GetY());
-                    p = RoadMesh.TransformPointToMeshSpace(p);
-                    if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                        && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-                    {
-                        Debug.Log("Tracer node: added an intersection in the beginning, tangent: " + tangent);
-                    }
                 }
             }
             if(vertices.Count > 20000)
@@ -214,7 +198,7 @@ public class RoadMesh : MonoBehaviour
 
             List<RoadEndPoint> endPoints = intersectionNodes[node];
             //TODO: Should work for intersections with 2 nodes as well
-            if(endPoints.Count < 2)
+            if(endPoints.Count <= 1)
             {
                 // Skip the node if it has less than two end points. Then it is not an intersection
                 continue;

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -75,6 +75,7 @@ public class RoadMesh : MonoBehaviour
             {
                 RoadNode a = path[i];
                 RoadNode b = path[i+1];
+
                 // Get hwy type from the second node in the path, since the intersection may be of another type
                 if(hwyType == RoadNode.HighwayType.NONE) hwyType = b.GetHighwayType();
                 Vector3 posA = TransformPointToMeshSpace(a.GetPosAsVector2());
@@ -217,6 +218,14 @@ public class RoadMesh : MonoBehaviour
             {
                 // Skip the node if it has less than two end points. Then it is not an intersection
                 continue;
+            }
+
+            Vector2 p = new Vector2(node.GetX(), node.GetY());
+            p = RoadMesh.TransformPointToMeshSpace(p);
+            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+            {
+                Debug.Log("Tracer node was found as an intersection. endPoints count: " + endPoints.Count);
             }
 
             // Order the end points by angle

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -142,13 +142,6 @@ public class RoadMesh : MonoBehaviour
                 // Set the last end point for the next path segment
                 previousRoadEndPoint = new RoadEndPoint(leftEndPoint, rightEndPoint, vertices.Count-2, vertices.Count-1, tangent, hwyType, storedPathMeshes[currentMeshCounter]);
                 
-                Vector2 po = new Vector2(b.GetX(), b.GetY());
-                po = RoadMesh.TransformPointToMeshSpace(po);
-                if(po.x-0.00001 < 6.56414 && po.x+0.00001 > 6.56414
-                    && po.y-0.00001 < 3.492355 && po.y+0.00001 > -3.492355)
-                {
-                    Debug.Log("Tracer node was found when reading paths. Index " + i + " out of " + (path.Count-1));
-                }
 
                 if(b.IsIntersection())
                 {
@@ -159,6 +152,8 @@ public class RoadMesh : MonoBehaviour
                     // Have to swap places of the right/left vertices here, at the end of the path, so that the intersection checker
                     // really looks at the left end point of a and right end point of b
                     intersectionNodes[b].Add(new RoadEndPoint(rightEndPoint, leftEndPoint, vertices.Count-1, vertices.Count-2, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+
+                    MapDebugHelper.ConditionalNodeLog(b, "Tracer node was found when reading paths. Added a b-intersection");
                 }
                 // If this is the beginning or end node of the path, store it as an intersection candidate
                 if(a.IsIntersection())
@@ -168,6 +163,7 @@ public class RoadMesh : MonoBehaviour
                         intersectionNodes[a] = new List<RoadEndPoint>();
                     }
                     intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+                    MapDebugHelper.ConditionalNodeLog(a, "Tracer node was found when reading paths. Added a a-intersection");
                 }
             }
             if(vertices.Count > 20000)
@@ -204,14 +200,6 @@ public class RoadMesh : MonoBehaviour
                 continue;
             }
 
-            Vector2 p = new Vector2(node.GetX(), node.GetY());
-            p = RoadMesh.TransformPointToMeshSpace(p);
-            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-            {
-                Debug.Log("Tracer node was found as an intersection. endPoints count: " + endPoints.Count);
-            }
-
             // Order the end points by angle
             RoadEndPoint[] endPointsSorted = endPoints.OrderBy(v => Vector3.SignedAngle(v.tangent, Vector3.right, -Vector3.up)).ToArray();
 
@@ -227,6 +215,18 @@ public class RoadMesh : MonoBehaviour
                 RoadEndPoint b = endPointsSorted[(i+1)%endPointsSorted.Length];
 
                 midPoint += (a.rightPoint + a.leftPoint)/2;
+
+                Vector2 p2 = new Vector3(node.GetX(), node.GetY());
+                Vector3 p = RoadMesh.TransformPointToMeshSpace(p2);
+                if(p.x-0.00005 < 6.144524 && p.x+0.00005 > 6.144524
+                    && p.z-0.00005 < -7.995605 && p.z+0.00005 > -7.995605)
+                {
+                    Debug.Log("Endpoint collision check: (a.rightPoint = "
+                            + a.rightPoint.x + ", " + a.rightPoint.z + "), (b.leftPoint = "
+                            + b.leftPoint.x + ", " + b.leftPoint.z + "), (a.tangent = "
+                            + a.tangent.x + ", " + a.tangent.z + "), b.tangent = "
+                            + b.tangent.x + ", " + b.tangent.z + ")");
+                }
                 
                 // Get the intersection point
                 // Get the right pos from end point 1 and left pos from end point 2

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -201,7 +201,7 @@ public class RoadMesh : MonoBehaviour
             }
 
             // Order the end points by angle
-            RoadEndPoint[] endPointsSorted = endPoints.OrderBy(v => Vector3.SignedAngle(v.tangent, Vector3.right, -Vector3.up)).ToArray();
+            RoadEndPoint[] endPointsSorted = endPoints.OrderBy(v => Vector2.SignedAngle(new Vector2(v.tangent.x, v.tangent.z), Vector2.right)).ToArray();
 
             List<Vector3> storedIntersections = new List<Vector3>();
 

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -78,8 +78,7 @@ public class RoadMesh : MonoBehaviour
                 RoadNode a = path.Get(i);
                 RoadNode b = path.Get(i+1);
 
-                // Get hwy type from the second node in the path, since the intersection may be of another type
-                if(hwyType == RoadNode.HighwayType.NONE) hwyType = b.GetHighwayType();
+                if(hwyType == RoadNode.HighwayType.NONE) hwyType = path.GetHighwayType();
                 Vector3 posA = TransformPointToMeshSpace(a.GetPosAsVector2());
                 Vector3 posB = TransformPointToMeshSpace(b.GetPosAsVector2());
                 Vector3 tangent = (posB - posA).normalized;

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -162,7 +162,7 @@ public class RoadMesh : MonoBehaviour
                     {
                         intersectionNodes[a] = new List<RoadEndPoint>();
                     }
-                    intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, tangent, hwyType, storedPathMeshes[currentMeshCounter]));
+                    intersectionNodes[a].Add(new RoadEndPoint(leftStartPoint, rightStartPoint, vertices.Count-4, vertices.Count-3, -tangent, hwyType, storedPathMeshes[currentMeshCounter]));
                     MapDebugHelper.ConditionalNodeLog(a, "Tracer node was found when reading paths. Added a a-intersection");
                 }
             }

--- a/unity-project/Assets/Scripts/RoadMesh.cs
+++ b/unity-project/Assets/Scripts/RoadMesh.cs
@@ -6,7 +6,7 @@ using UnityEditor;
 
 public class RoadMesh : MonoBehaviour
 {
-    private struct RoadEndPoint
+    private class RoadEndPoint
     {
         public Vector3 leftPoint;
         public Vector3 rightPoint;
@@ -15,6 +15,7 @@ public class RoadMesh : MonoBehaviour
         public Vector3 tangent;
         public RoadNode.HighwayType hwyType;
         public Mesh associatedMesh;
+        public Vector3 associatedIntersection;
 
         public RoadEndPoint(Vector3 leftPoint, Vector3 rightPoint, int leftIndex, int rightIndex, Vector3 tangent, RoadNode.HighwayType hwyType, Mesh associatedMesh)
         {
@@ -25,6 +26,7 @@ public class RoadMesh : MonoBehaviour
             this.tangent = tangent;
             this.hwyType = hwyType;
             this.associatedMesh = associatedMesh;
+            this.associatedIntersection = Vector3.zero;
         }
     }
 

--- a/unity-project/Assets/Scripts/RoadNode.cs
+++ b/unity-project/Assets/Scripts/RoadNode.cs
@@ -32,6 +32,7 @@ public class RoadNode
     private float _xCoord;
     private float _yCoord;
     private HighwayType _highwayType;
+    private bool _intersection;
 
     public static HighwayType GetHighwayTypeFromString(string input)
     {
@@ -44,6 +45,7 @@ public class RoadNode
         _xCoord = x;
         _yCoord = y;
         _highwayType = highwayType;
+        _intersection = false;
     }
 
     public float GetX()
@@ -64,6 +66,16 @@ public class RoadNode
     public Vector2 GetPosAsVector2()
     {
         return new Vector2(_xCoord, _yCoord);
+    }
+
+    public bool IsIntersection()
+    {
+        return _intersection;
+    }
+
+    public void SetIntersection()
+    {
+        _intersection = true;
     }
 
 }

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -50,15 +50,17 @@ public class RoadNodeCollection
 
                 if(i>0 && i<path.Count()-1 && _visitedCount[node] > 1)
                 {
+                    MapDebugHelper.ConditionalNodeLog(node, "Tracer node was split");
+                    
                     // This is an intersection, we should split the path
                     RoadPath path2 = new RoadPath(path.GetHighwayType());
-                    path2.Add(node); // First add the intersection point
-                    for(int j=i+1; j<path.Count(); j++)
+                    for(int j=0; j<i; j++)
                     {
                         // Move all other points from the first path to the second
-                        path2.Add(path.Get(j));
-                        path.RemoveAt(j);
+                        path2.Add(path.Get(0));
+                        path.RemoveAt(0);
                     }
+                    path2.Add(node); // Finally add the intersection point
                     // Queue the new path, deal with it in a later iteration
                     tentativePaths.Enqueue(path2);
                     break;

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -46,12 +46,8 @@ public class RoadNodeCollection
             {
                 RoadNode node = path.Get(i);
 
-                MapDebugHelper.ConditionalNodeLog(node, "Tracer node was found when building paths");
-
                 if(i>0 && i<path.Count()-1 && _visitedCount[node] > 1)
                 {
-                    MapDebugHelper.ConditionalNodeLog(node, "Tracer node was split");
-                    
                     // This is an intersection, we should split the path
                     RoadPath path2 = new RoadPath(path.GetHighwayType());
                     for(int j=0; j<i; j++)
@@ -121,9 +117,6 @@ public class RoadNodeCollection
             if(_readNodesByCoord[point.x][point.y].IsIntersection())
             {
                 Vector3 point3D = RoadMesh.TransformPointToMeshSpace(point);
-                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection."
-                        + " Center: + " + point3D.x + ", " + point3D.z);
-                //Debug.Log("Found intersection: (" + point3D.x + ", " + point3D.z + ")");
             }
             _readNodesByCoord[point.x][point.y].SetIntersection();
             return _readNodesByCoord[point.x][point.y];

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -26,15 +26,6 @@ public class RoadNodeCollection
             // Generate and add the node
             RoadNode node = GetNode(points[i], hwyType);
 
-            Vector2 p = points[i];
-            p = RoadMesh.TransformPointToMeshSpace(p);
-            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-            {
-                Debug.Log("Tracer node was gotten");
-            }
-
-
             path.Add(node);
             BumpVisitedCount(node);
         }
@@ -130,13 +121,8 @@ public class RoadNodeCollection
     {
         if(NodeHasBeenRead(point))
         {
-            // TODO: Compare node by coordinates to see if we can filter it out, the try to follow it later in the pipeline
-            Vector3 p = RoadMesh.TransformPointToMeshSpace(point);
-            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-            {
-                Debug.Log("The tracer node had already been read: " + p.x + ", " + p.z);
-            }
+            // Node has now been read more than once, therefore mark it as an intersection
+            _readNodesByCoord[point.x][point.y].SetIntersection();
             return _readNodesByCoord[point.x][point.y];
         }
         else

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -46,13 +46,7 @@ public class RoadNodeCollection
             {
                 RoadNode node = path[i];
 
-                Vector2 p = new Vector2(node.GetX(), node.GetY());
-                p = RoadMesh.TransformPointToMeshSpace(p);
-                if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
-                    && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
-                {
-                    Debug.Log("Tracer node was found when building paths");
-                }
+                MapDebugHelper.ConditionalNodeLog(node, "Tracer node was found when building paths");
 
                 if(i>0 && i<path.Count-1 && _visitedCount[node] > 1)
                 {
@@ -122,6 +116,10 @@ public class RoadNodeCollection
         if(NodeHasBeenRead(point))
         {
             // Node has now been read more than once, therefore mark it as an intersection
+            if(_readNodesByCoord[point.x][point.y].IsIntersection())
+            {
+                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection");
+            }
             _readNodesByCoord[point.x][point.y].SetIntersection();
             return _readNodesByCoord[point.x][point.y];
         }
@@ -130,22 +128,5 @@ public class RoadNodeCollection
             return AddAndReturnNode(point, hwyType);
         }
     }
-/*
-    private void AddNeighbourRelation(Vector2 point1, Vector2 point2)
-    {
-        if(NodeExists(point1) && NodeExists(point2))
-        {
-            RoadNode node1 = GetNode(point1);
-            RoadNode node2 = GetNode(point2);
-            node1.AddNeighbour(node2);
-            node2.AddNeighbour(node1);
-        }
-        else
-        {
-            Debug.LogError("RoadNodeCollection tried to add a neighbour relation for two nodes that do not exist: "
-                + point1 + ", " + point2);
-        }
-    }
-    */
 
 }

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -118,9 +118,9 @@ public class RoadNodeCollection
             // Node has now been read more than once, therefore mark it as an intersection
             if(_readNodesByCoord[point.x][point.y].IsIntersection())
             {
-                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection."
-                        + " Center: + " + point.x + ", " + point.y);
                 Vector3 point3D = RoadMesh.TransformPointToMeshSpace(point);
+                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection."
+                        + " Center: + " + point3D.x + ", " + point3D.z);
                 //Debug.Log("Found intersection: (" + point3D.x + ", " + point3D.z + ")");
             }
             _readNodesByCoord[point.x][point.y].SetIntersection();

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -6,13 +6,13 @@ public class RoadNodeCollection
     private Dictionary<float, Dictionary<float, RoadNode>> _readNodesByCoord
         = new Dictionary<float, Dictionary<float, RoadNode>>();
 
-    private Queue<List<RoadNode>> _readPaths = new Queue<List<RoadNode>>();
+    private Queue<RoadPath> _readPaths = new Queue<RoadPath>();
 
     private Dictionary<RoadNode, int> _visitedCount = new Dictionary<RoadNode, int>();
 
     public void ReadPath(List<Vector2> points, RoadNode.HighwayType hwyType)
     {
-        List<RoadNode> path = new List<RoadNode>();
+        RoadPath path = new RoadPath(hwyType);
         for(int i=0; i<points.Count; i++)
         {
             // Cleanup, ignore all successive duplicate nodes in the paths
@@ -32,31 +32,31 @@ public class RoadNodeCollection
         _readPaths.Enqueue(path);
     }
 
-    public List<List<RoadNode>> BuildAndGetPaths()
+    public List<RoadPath> BuildAndGetPaths()
     {
-        Queue<List<RoadNode>> tentativePaths = _readPaths;
-        List<List<RoadNode>> outPaths = new List<List<RoadNode>>();
+        Queue<RoadPath> tentativePaths = _readPaths;
+        List<RoadPath> outPaths = new List<RoadPath>();
 
         int crash_safe = 0;
         while(tentativePaths.Count > 0)
         {
-            List<RoadNode> path = tentativePaths.Dequeue();
+            RoadPath path = tentativePaths.Dequeue();
             
-            for(int i=0; i<path.Count; i++)
+            for(int i=0; i<path.Count(); i++)
             {
-                RoadNode node = path[i];
+                RoadNode node = path.Get(i);
 
                 MapDebugHelper.ConditionalNodeLog(node, "Tracer node was found when building paths");
 
-                if(i>0 && i<path.Count-1 && _visitedCount[node] > 1)
+                if(i>0 && i<path.Count()-1 && _visitedCount[node] > 1)
                 {
                     // This is an intersection, we should split the path
-                    List<RoadNode> path2 = new List<RoadNode>();
+                    RoadPath path2 = new RoadPath(path.GetHighwayType());
                     path2.Add(node); // First add the intersection point
-                    for(int j=i+1; j<path.Count; j++)
+                    for(int j=i+1; j<path.Count(); j++)
                     {
                         // Move all other points from the first path to the second
-                        path2.Add(path[j]);
+                        path2.Add(path.Get(j));
                         path.RemoveAt(j);
                     }
                     // Queue the new path, deal with it in a later iteration

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -25,6 +25,16 @@ public class RoadNodeCollection
 
             // Generate and add the node
             RoadNode node = GetNode(points[i], hwyType);
+
+            Vector2 p = points[i];
+            p = RoadMesh.TransformPointToMeshSpace(p);
+            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+            {
+                Debug.Log("Tracer node was gotten");
+            }
+
+
             path.Add(node);
             BumpVisitedCount(node);
         }
@@ -44,6 +54,15 @@ public class RoadNodeCollection
             for(int i=0; i<path.Count; i++)
             {
                 RoadNode node = path[i];
+
+                Vector2 p = new Vector2(node.GetX(), node.GetY());
+                p = RoadMesh.TransformPointToMeshSpace(p);
+                if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                    && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+                {
+                    Debug.Log("Tracer node was found when building paths");
+                }
+
                 if(i>0 && i<path.Count-1 && _visitedCount[node] > 1)
                 {
                     // This is an intersection, we should split the path
@@ -89,7 +108,9 @@ public class RoadNodeCollection
     private RoadNode AddAndReturnNode(Vector2 point, RoadNode.HighwayType hwyType)
     {
         if(!_readNodesByCoord.ContainsKey(point.x))
+        {
             _readNodesByCoord[point.x] = new Dictionary<float, RoadNode>();
+        }
 
         if(!_readNodesByCoord[point.x].ContainsKey(point.y))
         {
@@ -109,6 +130,13 @@ public class RoadNodeCollection
     {
         if(NodeHasBeenRead(point))
         {
+            // TODO: Compare node by coordinates to see if we can filter it out, the try to follow it later in the pipeline
+            Vector3 p = RoadMesh.TransformPointToMeshSpace(point);
+            if(p.x-0.00001 < 6.56414 && p.x+0.00001 > 6.56414
+                && p.y-0.00001 < 3.492355 && p.y+0.00001 > -3.492355)
+            {
+                Debug.Log("The tracer node had already been read: " + p.x + ", " + p.z);
+            }
             return _readNodesByCoord[point.x][point.y];
         }
         else

--- a/unity-project/Assets/Scripts/RoadNodeCollection.cs
+++ b/unity-project/Assets/Scripts/RoadNodeCollection.cs
@@ -118,7 +118,10 @@ public class RoadNodeCollection
             // Node has now been read more than once, therefore mark it as an intersection
             if(_readNodesByCoord[point.x][point.y].IsIntersection())
             {
-                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection");
+                MapDebugHelper.ConditionalNodeLog(point, "Tracer node was found three times or more when reading nodes. Marked as an intersection."
+                        + " Center: + " + point.x + ", " + point.y);
+                Vector3 point3D = RoadMesh.TransformPointToMeshSpace(point);
+                //Debug.Log("Found intersection: (" + point3D.x + ", " + point3D.z + ")");
             }
             _readNodesByCoord[point.x][point.y].SetIntersection();
             return _readNodesByCoord[point.x][point.y];

--- a/unity-project/Assets/Scripts/RoadPath.cs
+++ b/unity-project/Assets/Scripts/RoadPath.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+public class RoadPath
+{
+    private List<RoadNode> _nodes;
+    private RoadNode.HighwayType _highwayType;
+
+    public RoadPath(RoadNode.HighwayType highwayType)
+    {
+        _nodes = new List<RoadNode>();
+        _highwayType = highwayType;
+    }
+
+    public RoadNode.HighwayType GetHighwayType()
+    {
+        return _highwayType;
+    }
+
+    public void Add(RoadNode node)
+    {
+        _nodes.Add(node);
+    }
+
+    public RoadNode Get(int i)
+    {
+        return _nodes[i];
+    }
+
+    public int Count()
+    {
+        return _nodes.Count;
+    }
+
+    public void RemoveAt(int i)
+    {
+        _nodes.RemoveAt(i);
+    }
+}

--- a/unity-project/Assets/Scripts/RoadPath.cs.meta
+++ b/unity-project/Assets/Scripts/RoadPath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 845dd5f7bfb74dac8ad69694bf3e51f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #22 and a whole lot of other graphical bugs. Now the mesh rendering part is working as expected. The following bugs were fixed in this PQ:

- Solved an indexing error that made paths of length 2 not render.
- Use the SignedAngle function when sorting intersection endpoints by tangent angle. The previous method (using only Angle) turned out not to be working.
- The tangent direction was set to negative if the intersection endpoint was found in the beginning of a path. Now all tangents point towards the center of the intersection.
- The sorted endpoints are now also used when generating the triangles of the intersection. Previously they were gone over in an unsorted order, meaning that the triangles were not created from the correct corners.
- All polygon objects are skipped. This caused a graphical bug, since they were treated as cyclic paths.
- Fixed an indexing error that caused problems when splitting paths at intersection nodes.